### PR TITLE
Tune on-screen image cache

### DIFF
--- a/CatBoardApp/View/SquareGalleryImageAsync.swift
+++ b/CatBoardApp/View/SquareGalleryImageAsync.swift
@@ -11,7 +11,9 @@ struct SquareGalleryImageAsync: View {
 
             KFImage(source: url.map { .network($0) })
                 .setProcessor(DownsamplingImageProcessor(size: CGSize(width: 200, height: 200)))
-                .cacheMemoryOnly()
+                .memoryCacheExpiration(.minutes(1))
+                .diskCacheExpiration(.expired)
+                .cacheOriginalImage(false)
                 .placeholder {
                     Color(.secondarySystemBackground)
                         .frame(width: size, height: size)

--- a/CatImageLoader/CatImageLoader.swift
+++ b/CatImageLoader/CatImageLoader.swift
@@ -7,6 +7,10 @@ public actor CatImageLoader: CatImageLoaderProtocol {
         // Kingfisherのキャッシュ設定
         let diskCache = KingfisherManager.shared.cache.diskStorage
 
+        // メモリキャッシュの制限: 200MB
+        let memoryCache = KingfisherManager.shared.cache.memoryStorage
+        memoryCache.config.totalCostLimit = 200 * 1024 * 1024
+
         // ディスクキャッシュの制限: 500MB
         diskCache.config.sizeLimit = 500 * 1024 * 1024
         diskCache.config.expiration = .days(3) // 3日間保持

--- a/CatImagePrefetcher/CatImagePrefetcher.swift
+++ b/CatImagePrefetcher/CatImagePrefetcher.swift
@@ -62,13 +62,15 @@ public actor CatImagePrefetcher {
         prefetchTask?.cancel()
 
         isPrefetching = true
-        prefetchTask = Task { [self] in
+        prefetchTask = Task { [weak self] in
+            guard let self else { return }
             do {
-                try await prefetchImages()
+                try await self.prefetchImages()
             } catch {
                 print("プリフェッチ中にエラーが発生: \(error.localizedDescription)")
             }
-            isPrefetching = false
+            self.isPrefetching = false
+            self.prefetchTask = nil
         }
     }
 

--- a/CatImagePrefetcher/CatImagePrefetcher.swift
+++ b/CatImagePrefetcher/CatImagePrefetcher.swift
@@ -63,18 +63,24 @@ public actor CatImagePrefetcher {
 
         isPrefetching = true
         prefetchTask = Task { [weak self] in
-            guard let self else { return }
-            do {
-                try await self.prefetchImages()
-            } catch {
-                print("プリフェッチ中にエラーが発生: \(error.localizedDescription)")
-            }
-            self.isPrefetching = false
-            self.prefetchTask = nil
+            await self?.performPrefetchFlow()
         }
     }
 
     // MARK: - Private Methods
+
+    private func performPrefetchFlow() async {
+        defer {
+            self.isPrefetching = false
+            self.prefetchTask = nil
+        }
+
+        do {
+            try await prefetchImages()
+        } catch {
+            print("プリフェッチ中にエラーが発生: \(error.localizedDescription)")
+        }
+    }
 
     private func prefetchImages() async throws {
         let currentCount = try await getPrefetchedCount()
@@ -107,7 +113,7 @@ public actor CatImagePrefetcher {
             attempts += 1
 
             // 6. ログ出力
-            try await print(
+            print(
                 "プリフェッチ進捗: \(loadedImages.count)枚中\(screenedModels.count)枚通過 "
                     + "(現在\(try await getPrefetchedCount())枚)"
             )

--- a/CatImageURLRepository/CatImageURLRepository.swift
+++ b/CatImageURLRepository/CatImageURLRepository.swift
@@ -96,11 +96,11 @@ public actor CatImageURLRepository: CatImageURLRepositoryProtocol {
         refillTask = Task { [weak self] in
             guard let self else { return }
             await self.performBackgroundURLRefill()
-            await self.clearRefillTask()
         }
     }
 
     private func performBackgroundURLRefill() async {
+        defer { clearRefillTask() }
         do {
             if loadedImageURLs.count > loadedURLThreshold { return }
 

--- a/CatImageURLRepository/CatImageURLRepository.swift
+++ b/CatImageURLRepository/CatImageURLRepository.swift
@@ -149,7 +149,7 @@ public actor CatImageURLRepository: CatImageURLRepositoryProtocol {
 
             if loadedImageURLs.count <= loadedURLThreshold {
                 print("loadedImageURLsが閾値を下回っているため、追加の補充を開始: 現在\(loadedImageURLs.count)枚")
-                await startBackgroundURLRefillLoadedURLs()
+                startBackgroundURLRefillLoadedURLs()
             }
         } catch {
             print("loadedImageURLsのバックグラウンド補充に失敗: \(error.localizedDescription)")

--- a/CatImageURLRepository/CatImageURLRepository.swift
+++ b/CatImageURLRepository/CatImageURLRepository.swift
@@ -93,42 +93,43 @@ public actor CatImageURLRepository: CatImageURLRepositoryProtocol {
             return
         }
 
-        refillTask = Task { [self] in
+        refillTask = Task { [weak self] in
+            guard let self else { return }
             do {
-                if loadedImageURLs.count > loadedURLThreshold { return }
+                if self.loadedImageURLs.count > self.loadedURLThreshold { return }
 
-                let neededToLoad = maxLoadedURLCount - loadedImageURLs.count
+                let neededToLoad = self.maxLoadedURLCount - self.loadedImageURLs.count
                 print(
-                    "loadedImageURLs補充開始: 現在\(loadedImageURLs.count)枚 → 目標\(maxLoadedURLCount)枚(\(neededToLoad)枚追加予定)"
+                    "loadedImageURLs補充開始: 現在\(self.loadedImageURLs.count)枚 → 目標\(self.maxLoadedURLCount)枚(\(neededToLoad)枚追加予定)"
                 )
 
                 // まずデータベースから読み込める分を読み込む
-                let storedURLs = try await loadStoredURLsFromSwiftData(limit: neededToLoad)
+                let storedURLs = try await self.loadStoredURLsFromSwiftData(limit: neededToLoad)
                 if !storedURLs.isEmpty {
-                    loadedImageURLs += storedURLs
-                    print("loadedImageURLs補充完了: \(storedURLs.count)枚追加 → 現在\(loadedImageURLs.count)枚")
+                    self.loadedImageURLs += storedURLs
+                    print("loadedImageURLs補充完了: \(storedURLs.count)枚追加 → 現在\(self.loadedImageURLs.count)枚")
                 }
 
                 // まだ必要な分があればAPIから取得
-                if loadedImageURLs.count < maxLoadedURLCount {
-                    let remainingToLoad = maxLoadedURLCount - loadedImageURLs.count
-                    let fetched = try await apiClient.fetchImageURLs(
+                if self.loadedImageURLs.count < self.maxLoadedURLCount {
+                    let remainingToLoad = self.maxLoadedURLCount - self.loadedImageURLs.count
+                    let fetched = try await self.apiClient.fetchImageURLs(
                         totalCount: remainingToLoad,
-                        batchSize: apiFetchBatchSize
+                        batchSize: self.apiFetchBatchSize
                     )
-                    loadedImageURLs += fetched
-                    print("APIからloadedImageURLsへ補充: \(fetched.count)枚追加 → 現在\(loadedImageURLs.count)枚")
+                    self.loadedImageURLs += fetched
+                    print("APIからloadedImageURLsへ補充: \(fetched.count)枚追加 → 現在\(self.loadedImageURLs.count)枚")
                 }
 
                 // データベースの補充
-                var currentStored = try await fetchStoredURLCount()
-                if currentStored <= storedURLThreshold {
-                    print("SwiftData URL補充開始: 現在\(currentStored)件 → 目標\(maxStoredURLCount)件")
-                    while currentStored < maxStoredURLCount {
-                        let remaining = maxStoredURLCount - currentStored
-                        let times = Int(ceil(Double(remaining) / Double(apiFetchBatchSize)))
-                        let newlyStored = try await fetchAndStoreImageURLsFromAPIToSwiftData(
-                            imageCountPerFetch: apiFetchBatchSize,
+                var currentStored = try await self.fetchStoredURLCount()
+                if currentStored <= self.storedURLThreshold {
+                    print("SwiftData URL補充開始: 現在\(currentStored)件 → 目標\(self.maxStoredURLCount)件")
+                    while currentStored < self.maxStoredURLCount {
+                        let remaining = self.maxStoredURLCount - currentStored
+                        let times = Int(ceil(Double(remaining) / Double(self.apiFetchBatchSize)))
+                        let newlyStored = try await self.fetchAndStoreImageURLsFromAPIToSwiftData(
+                            imageCountPerFetch: self.apiFetchBatchSize,
                             timesOfFetch: times
                         )
                         if newlyStored == 0 { break }
@@ -136,18 +137,18 @@ public actor CatImageURLRepository: CatImageURLRepositoryProtocol {
                     }
                     print("SwiftData URL補充完了: \(currentStored)件")
                 } else {
-                    print("SwiftData URL補充不要: 現在\(currentStored)件(閾値\(storedURLThreshold)件)")
+                    print("SwiftData URL補充不要: 現在\(currentStored)件(閾値\(self.storedURLThreshold)件)")
                 }
-                print("キャッシュ更新完了: loadedImageURLs=\(loadedImageURLs.count)枚, SwiftData=\(currentStored)件")
+                print("キャッシュ更新完了: loadedImageURLs=\(self.loadedImageURLs.count)枚, SwiftData=\(currentStored)件")
 
-                if loadedImageURLs.count <= loadedURLThreshold {
-                    print("loadedImageURLsが閾値を下回っているため、追加の補充を開始: 現在\(loadedImageURLs.count)枚")
-                    startBackgroundURLRefillLoadedURLs()
+                if self.loadedImageURLs.count <= self.loadedURLThreshold {
+                    print("loadedImageURLsが閾値を下回っているため、追加の補充を開始: 現在\(self.loadedImageURLs.count)枚")
+                    await self.startBackgroundURLRefillLoadedURLs()
                 }
             } catch {
                 print("loadedImageURLsのバックグラウンド補充に失敗: \(error.localizedDescription)")
             }
-            refillTask = nil
+            self.refillTask = nil
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ LazyVStackとTieredGridLayoutを用いて、メモリ使用量を最適化しな
 actor、MainActorを活用した並行処理の実装により、Badアクセスエラーを完全に排除しました。各コンポーネント（CatImagePrefetcher、CatImageURLRepository、CatImageLoader、CatImageScreener）はactorとして実装され、データ競合を防止しながら効率的な並列処理を実現します。UIの更新やSwiftDataの操作はMainActorで明示的に制御され、予測可能な状態管理を実現しています。
 
 ### 3. マルチレイヤーキャッシュシステム
-Kingfisher、SwiftDataを活用したキャッシュシステムを実装。メモリキャッシュ、ディスクキャッシュ（500MBに制限、3日間有効）、SwiftDataによる取得したURL、プリフェッチしたURLの永続化を組み合わせ、より速い表示を実現します。
+Kingfisher、SwiftDataを活用したキャッシュシステムを実装。メモリキャッシュ（200MBに制限）、ディスクキャッシュ（500MBに制限、3日間有効）、SwiftDataによる取得したURL、プリフェッチしたURLの永続化を組み合わせ、より速い表示を実現します。プリフェッチ時は `.memoryCacheExpiration(.hours(1))` と `.diskCacheExpiration(.days(7))`、表示時は `.memoryCacheExpiration(.minutes(1))` と `.diskCacheExpiration(.expired)` を使い、表示後は短期でキャッシュを解放します。
 
 ### 4. 画像URLの自動管理
 CatImageURLRepositoryが画像URLの在庫を監視し、表示可能なURLが一定枚数未満になった時点で自動的にCatAPIClientを通じて新しい画像URLを取得します。この補充処理はバックグラウンドで非同期実行され、効率的な補充を実現します。取得したURLはSwiftDataを通じて永続化され、次回起動時にも即座に利用可能な状態を維持します。


### PR DESCRIPTION
## Summary
- constrain Kingfisher memory cache to 200 MB and keep the disk cache at 500 MB
- release prefetch tasks once they finish
- avoid retaining CatImageURLRepository via refill task
- shorten cache lifetime for images displayed on screen
- document cache policy

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840f7d52f5c8320842db326056eb9c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- メモリキャッシュのサイズ上限（200MB）が設定され、キャッシュの有効期限や保存ポリシーがより詳細に調整されました。

- **バグ修正**
	- 画像プリフェッチやURLリフィル処理でメモリリークを防ぐための改善が行われました。

- **ドキュメント**
	- キャッシュシステムの仕様や有効期限に関する説明がREADMEに追加・更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->