### PR TITLE
populate-info-plist

### DIFF
--- a/CatBoardApp/Info.plist
+++ b/CatBoardApp/Info.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ja</string>
 	<key>CFBundleDisplayName</key>
 	<string>CatBoard</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>com.akitorahayashi.CatBoardApp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UIRequiresFullScreen</key>

--- a/CatBoardTests/Info.plist
+++ b/CatBoardTests/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ja</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>com.akitorahayashi.CatBoardTests</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 </dict>
 </plist>

--- a/CatBoardUITests/Info.plist
+++ b/CatBoardUITests/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ja</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>com.akitorahayashi.CatBoardUITests</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -15,8 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
+	<key>TestTargetName</key>
+	<string>CatBoardApp</string>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,13 @@ APP_BUNDLE_ID := com.example.catboardapp
 # === Boot simulator ===
 .PHONY: boot
 boot:
-ifndef LOCAL_SIMULATOR_UDID
-	$(error LOCAL_SIMULATOR_UDID is not set. Please uncomment and set it in the Makefile)
-endif
 	@echo "🚀 Booting local simulator: $(LOCAL_SIMULATOR_NAME) (OS: $(LOCAL_SIMULATOR_OS), UDID: $(LOCAL_SIMULATOR_UDID))"
-	xcrun simctl boot $(LOCAL_SIMULATOR_UDID) || echo "Simulator already booted."
+	@if xcrun simctl list | grep -A1 "$(LOCAL_SIMULATOR_UDID)" | grep -q "Booted"; then \
+		echo "⚡️ Simulator is already booted."; \
+	else \
+		xcrun simctl boot $(LOCAL_SIMULATOR_UDID); \
+		echo "✅ Simulator booted."; \
+	fi
 	open -a Simulator
 	@echo "✅ Local simulator boot command executed."
 
@@ -108,7 +110,7 @@ endif
 		CODE_SIGNING_ALLOWED=NO \
 		| xcbeautify
 	@echo "✅ Release build completed."
-	@echo "📲 リリースビルドをシミュレータ（$(LOCAL_SIMULATOR_NAME)）にインストールしています..."
+	@echo "📲 Installing release build to simulator ($(LOCAL_SIMULATOR_NAME))..."
 	xcrun simctl install $(LOCAL_SIMULATOR_UDID) $(OUTPUT_DIR)/release/DerivedData/Build/Products/Release-iphonesimulator/$(APP_SCHEME).app
 	@echo "✅ Installed release build."
 	@echo "🚀 Launching app ($(APP_BUNDLE_ID)) on simulator ($(LOCAL_SIMULATOR_NAME))..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **その他**
  * アプリおよびテストの設定ファイルにおいて、言語、バンドルID、バージョン情報が静的な値に変更されました。
  * UIテスト用設定ファイルに「TestTargetName」キーが追加されました。
  * シミュレータの起動処理が改善され、既に起動中の場合はその旨が表示されるようになりました。
  * リリースビルドのシミュレータへのインストールメッセージが日本語から英語に変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->